### PR TITLE
Fast ompl path simplification, add ProjEST and pSBL planner types

### DIFF
--- a/tesseract_motion_planners/descartes/include/tesseract_motion_planners/descartes/descartes_robot_sampler.h
+++ b/tesseract_motion_planners/descartes/include/tesseract_motion_planners/descartes/descartes_robot_sampler.h
@@ -66,6 +66,8 @@ public:
 
   std::vector<descartes_light::StateSample<FloatType>> sample() const override;
 
+  virtual std::ostream& format(std::ostream& out) const override;
+
 private:
   /** @brief The target pose working frame */
   std::string target_working_frame_;

--- a/tesseract_motion_planners/descartes/include/tesseract_motion_planners/descartes/impl/descartes_robot_sampler.hpp
+++ b/tesseract_motion_planners/descartes/include/tesseract_motion_planners/descartes/impl/descartes_robot_sampler.hpp
@@ -215,6 +215,16 @@ std::vector<descartes_light::StateSample<FloatType>> DescartesRobotSampler<Float
   return samples;
 }
 
+template <typename FloatType>
+std::ostream& DescartesRobotSampler<FloatType>::format(std::ostream& out) const
+{
+  auto tr = this->target_pose_.translation();
+  auto rot = Eigen::Quaternion<double>(this->target_pose_.rotation());
+  out << "{ [x=" << tr.x() << ", y=" << tr.y() << ", z=" << tr.z() << "], [x=" << rot.x() << ", y=" << rot.y()
+      << ", z=" << rot.z() << ", w=" << rot.w() << "] }";
+  return out;
+}
+
 }  // namespace tesseract_planning
 
 #endif  // TESSERACT_MOTION_PLANNERS_DESCARTES_ROBOT_SAMPLER_HPP

--- a/tesseract_motion_planners/ompl/include/tesseract_motion_planners/ompl/ompl_planner_configurator.h
+++ b/tesseract_motion_planners/ompl/include/tesseract_motion_planners/ompl/ompl_planner_configurator.h
@@ -77,7 +77,9 @@ enum class OMPLPlannerType
   PRM = 10,
   PRMstar = 11,
   LazyPRMstar = 12,
-  SPARS = 13
+  SPARS = 13,
+  ProjEST = 14,
+  pSBL = 15
 };
 
 struct OMPLPlannerConfigurator
@@ -143,6 +145,58 @@ struct ESTConfigurator : public OMPLPlannerConfigurator
 
   /** @brief When close to goal select goal, with this probability. */
   double goal_bias = 0.05;
+
+  /** @brief Create the planner */
+  ompl::base::PlannerPtr create(ompl::base::SpaceInformationPtr si) const override;
+
+  OMPLPlannerType getType() const override;
+
+  /** @brief Serialize planner to xml */
+  tinyxml2::XMLElement* toXML(tinyxml2::XMLDocument& doc) const override;
+};
+
+struct ProjESTConfigurator : public OMPLPlannerConfigurator
+{
+  ProjESTConfigurator() = default;
+  ~ProjESTConfigurator() override = default;
+  ProjESTConfigurator(const ProjESTConfigurator&) = default;
+  ProjESTConfigurator& operator=(const ProjESTConfigurator&) = default;
+  ProjESTConfigurator(ProjESTConfigurator&&) = default;
+  ProjESTConfigurator& operator=(ProjESTConfigurator&&) = default;
+  ProjESTConfigurator(const tinyxml2::XMLElement& xml_element);
+
+  /** @brief Max motion added to tree */
+  double range = 0;
+
+  /** @brief When close to goal select goal, with this probability. */
+  double goal_bias = 0.05;
+
+  /** @brief Create the planner */
+  ompl::base::PlannerPtr create(ompl::base::SpaceInformationPtr si) const override;
+
+  OMPLPlannerType getType() const override;
+
+  /** @brief Serialize planner to xml */
+  tinyxml2::XMLElement* toXML(tinyxml2::XMLDocument& doc) const override;
+};
+
+struct pSBLConfigurator : public OMPLPlannerConfigurator
+{
+  pSBLConfigurator() = default;
+  ~pSBLConfigurator() override = default;
+  pSBLConfigurator(const pSBLConfigurator&) = default;
+  pSBLConfigurator& operator=(const pSBLConfigurator&) = default;
+  pSBLConfigurator(pSBLConfigurator&&) = default;
+  pSBLConfigurator& operator=(pSBLConfigurator&&) = default;
+  pSBLConfigurator(const tinyxml2::XMLElement& xml_element);
+
+  /** @brief Max motion added to tree */
+  double range = 0;
+
+  /** @brief When close to goal select goal, with this probability. */
+  //double goal_bias = 0.05;
+
+  uint thread_count;
 
   /** @brief Create the planner */
   ompl::base::PlannerPtr create(ompl::base::SpaceInformationPtr si) const override;

--- a/tesseract_motion_planners/ompl/include/tesseract_motion_planners/ompl/ompl_problem.h
+++ b/tesseract_motion_planners/ompl/include/tesseract_motion_planners/ompl/ompl_problem.h
@@ -103,6 +103,15 @@ struct OMPLProblem
   bool simplify = false;
 
   /**
+   * @brief call reduceVertices instead of simplifySolution() if the path is too long
+   *
+   * simplifySolution can take a long time and will try to reduce the number of steps to be as small as possible.  It
+   * runs a bunch of other filters on the path as well that add to the time.  Enabling this will only run
+   * reduceVertices(), which should be enough.  It will run the full simplifySolution if that fails.
+   */
+  bool fast_simplify_if_required = true;
+
+  /**
    * @brief Number of states in the output trajectory
    *   Note: This is ignored if the simplify is set to true.
    *   Note: The trajectory can be longer if original trajectory is longer and reducing the number of states causes

--- a/tesseract_motion_planners/ompl/include/tesseract_motion_planners/ompl/profile/ompl_default_plan_profile.h
+++ b/tesseract_motion_planners/ompl/include/tesseract_motion_planners/ompl/profile/ompl_default_plan_profile.h
@@ -80,6 +80,15 @@ public:
    */
   bool simplify = false;
 
+   /**
+   * @brief call reduceVertices instead of simplifySolution() if the path is too long
+   *
+   * simplifySolution can take a long time and will try to reduce the number of steps to be as small as possible.  It
+   * runs a bunch of other filters on the path as well that add to the time.  Enabling this will only run
+   * reduceVertices(), which should be enough.  It will run the full simplifySolution if that fails.
+   */
+  bool fast_simplify_if_required = true;
+
   /**
    * @brief This uses all available planning time to create the most optimized trajectory given the objective function.
    *

--- a/tesseract_motion_planners/ompl/src/ompl_motion_planner.cpp
+++ b/tesseract_motion_planners/ompl/src/ompl_motion_planner.cpp
@@ -220,7 +220,17 @@ tesseract_common::StatusCode OMPLMotionPlanner::solve(const PlannerRequest& requ
       {
         // Now try to simplify the trajectory to get it under the requested number of output states
         // The interpolate function only executes if the current number of states is less than the requested
-        p->simple_setup->simplifySolution();
+
+        auto time_start = ompl::time::now();
+        auto &path = p->simple_setup->getSolutionPath();
+        auto original_size = path.getStateCount();
+        // auto max_steps = path.getStateCount() - num_output_states + 1;
+        p->simple_setup->getPathSimplifier()->reduceVertices(path, 0, 0, 0.1);
+        auto simplify_time = ompl::time::seconds(ompl::time::now() - time_start);
+        CONSOLE_BRIDGE_logError("Simplify time: %f Original size: %i, reduced: %i", simplify_time, original_size, path.getStateCount());
+
+        
+        //p->simple_setup->simplifySolution(1.0);
         if (p->simple_setup->getSolutionPath().getStateCount() < num_output_states)
           p->simple_setup->getSolutionPath().interpolate(num_output_states);
       }

--- a/tesseract_motion_planners/ompl/src/ompl_motion_planner.cpp
+++ b/tesseract_motion_planners/ompl/src/ompl_motion_planner.cpp
@@ -220,17 +220,32 @@ tesseract_common::StatusCode OMPLMotionPlanner::solve(const PlannerRequest& requ
       {
         // Now try to simplify the trajectory to get it under the requested number of output states
         // The interpolate function only executes if the current number of states is less than the requested
-
-        auto time_start = ompl::time::now();
-        auto &path = p->simple_setup->getSolutionPath();
+        auto& path = p->simple_setup->getSolutionPath();
         auto original_size = path.getStateCount();
-        // auto max_steps = path.getStateCount() - num_output_states + 1;
-        p->simple_setup->getPathSimplifier()->reduceVertices(path, 0, 0, 0.1);
-        auto simplify_time = ompl::time::seconds(ompl::time::now() - time_start);
-        CONSOLE_BRIDGE_logError("Simplify time: %f Original size: %i, reduced: %i", simplify_time, original_size, path.getStateCount());
+        auto time_start = ompl::time::now();
 
-        
-        //p->simple_setup->simplifySolution(1.0);
+        if (p->fast_simplify_if_required)
+        {
+          auto max_steps = path.getStateCount() - num_output_states + 1;
+          p->simple_setup->getPathSimplifier()->reduceVertices(path, max_steps, 0);
+          if (path.getStateCount() > num_output_states)
+          {
+            CONSOLE_BRIDGE_logWarn("Quick simplification failed.  It produced %i states, but the maximum was %i.  "
+                                   "Running full simplifySolution()",
+                                   path.getStateCount(),
+                                   num_output_states);
+            p->simple_setup->simplifySolution();
+          }
+        }
+        else
+        {
+          p->simple_setup->simplifySolution();
+        }
+
+        auto simplify_time = ompl::time::seconds(ompl::time::now() - time_start);
+        CONSOLE_BRIDGE_logDebug(
+            "Simplify time: %f Original size: %i, reduced: %i", simplify_time, original_size, path.getStateCount());
+
         if (p->simple_setup->getSolutionPath().getStateCount() < num_output_states)
           p->simple_setup->getSolutionPath().interpolate(num_output_states);
       }

--- a/tesseract_motion_planners/ompl/src/ompl_planner_configurator.cpp
+++ b/tesseract_motion_planners/ompl/src/ompl_planner_configurator.cpp
@@ -225,24 +225,18 @@ tinyxml2::XMLElement* pSBLConfigurator::toXML(tinyxml2::XMLDocument& doc) const
   return ompl_xml;
 }
 
-
-pSBLConfigurator::pSBLConfigurator(const tinyxml2::XMLElement& xml_element)
-{
-
-}
-
+pSBLConfigurator::pSBLConfigurator(const tinyxml2::XMLElement& xml_element) {}
 
 ompl::base::PlannerPtr pSBLConfigurator::create(ompl::base::SpaceInformationPtr si) const
 {
   auto planner = std::make_shared<ompl::geometric::pSBL>(si);
   planner->setRange(range);
-  planner->setThreadCount(thread_count); 
-  
+  planner->setThreadCount(thread_count);
+
   return planner;
 }
 
 OMPLPlannerType pSBLConfigurator::getType() const { return OMPLPlannerType::pSBL; }
-
 
 LBKPIECE1Configurator::LBKPIECE1Configurator(const tinyxml2::XMLElement& xml_element)
 {

--- a/tesseract_motion_planners/ompl/src/ompl_planner_configurator.cpp
+++ b/tesseract_motion_planners/ompl/src/ompl_planner_configurator.cpp
@@ -40,6 +40,8 @@ TESSERACT_COMMON_IGNORE_WARNINGS_PUSH
 #include <ompl/geometric/planners/prm/PRMstar.h>
 #include <ompl/geometric/planners/prm/LazyPRMstar.h>
 #include <ompl/geometric/planners/prm/SPARS.h>
+#include <ompl/geometric/planners/est/ProjEST.h>
+#include <ompl/geometric/planners/sbl/pSBL.h>
 TESSERACT_COMMON_IGNORE_WARNINGS_POP
 
 #include <tesseract_motion_planners/ompl/ompl_planner_configurator.h>
@@ -145,6 +147,102 @@ tinyxml2::XMLElement* ESTConfigurator::toXML(tinyxml2::XMLDocument& doc) const
 
   return ompl_xml;
 }
+
+//############
+ProjESTConfigurator::ProjESTConfigurator(const tinyxml2::XMLElement& xml_element)
+{
+  // const tinyxml2::XMLElement* est_element = xml_element.FirstChildElement("ProjEST");
+  // const tinyxml2::XMLElement* range_element = est_element->FirstChildElement("Range");
+  // const tinyxml2::XMLElement* goal_bias_element = est_element->FirstChildElement("GoalBias");
+
+  // tinyxml2::XMLError status{ tinyxml2::XMLError::XML_SUCCESS };
+
+  // if (range_element != nullptr)
+  // {
+  //   std::string range_string;
+  //   status = tesseract_common::QueryStringText(range_element, range_string);
+  //   if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
+  //     throw std::runtime_error("OMPLConfigurator: EST: Error parsing Range string");
+
+  //   if (!tesseract_common::isNumeric(range_string))
+  //     throw std::runtime_error("OMPLConfigurator: EST: Range is not a numeric values.");
+
+  //   tesseract_common::toNumeric<double>(range_string, range);
+  // }
+
+  // if (goal_bias_element != nullptr)
+  // {
+  //   std::string goal_bias_string;
+  //   status = tesseract_common::QueryStringText(goal_bias_element, goal_bias_string);
+  //   if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
+  //     throw std::runtime_error("OMPLConfigurator: EST: Error parsing GoalBias string");
+
+  //   if (!tesseract_common::isNumeric(goal_bias_string))
+  //     throw std::runtime_error("OMPLConfigurator: EST: GoalBias is not a numeric values.");
+
+  //   tesseract_common::toNumeric<double>(goal_bias_string, goal_bias);
+  // }
+}
+
+ompl::base::PlannerPtr ProjESTConfigurator::create(ompl::base::SpaceInformationPtr si) const
+{
+  auto planner = std::make_shared<ompl::geometric::ProjEST>(si);
+  planner->setRange(range);
+  planner->setGoalBias(goal_bias);
+  return planner;
+}
+
+OMPLPlannerType ProjESTConfigurator::getType() const { return OMPLPlannerType::ProjEST; }
+
+tinyxml2::XMLElement* ProjESTConfigurator::toXML(tinyxml2::XMLDocument& doc) const
+{
+  tinyxml2::XMLElement* ompl_xml = doc.NewElement("EST");
+
+  tinyxml2::XMLElement* range_xml = doc.NewElement("Range");
+  range_xml->SetText(range);
+  ompl_xml->InsertEndChild(range_xml);
+
+  tinyxml2::XMLElement* goal_bias_xml = doc.NewElement("GoalBias");
+  goal_bias_xml->SetText(goal_bias);
+  ompl_xml->InsertEndChild(goal_bias_xml);
+
+  return ompl_xml;
+}
+
+
+tinyxml2::XMLElement* pSBLConfigurator::toXML(tinyxml2::XMLDocument& doc) const
+{
+  tinyxml2::XMLElement* ompl_xml = doc.NewElement("pSBL");
+
+  // tinyxml2::XMLElement* range_xml = doc.NewElement("Range");
+  // range_xml->SetText(range);
+  // ompl_xml->InsertEndChild(range_xml);
+
+  // tinyxml2::XMLElement* goal_bias_xml = doc.NewElement("GoalBias");
+  // goal_bias_xml->SetText(goal_bias);
+  // ompl_xml->InsertEndChild(goal_bias_xml);
+
+  return ompl_xml;
+}
+
+
+pSBLConfigurator::pSBLConfigurator(const tinyxml2::XMLElement& xml_element)
+{
+
+}
+
+
+ompl::base::PlannerPtr pSBLConfigurator::create(ompl::base::SpaceInformationPtr si) const
+{
+  auto planner = std::make_shared<ompl::geometric::pSBL>(si);
+  planner->setRange(range);
+  planner->setThreadCount(thread_count); 
+  
+  return planner;
+}
+
+OMPLPlannerType pSBLConfigurator::getType() const { return OMPLPlannerType::pSBL; }
+
 
 LBKPIECE1Configurator::LBKPIECE1Configurator(const tinyxml2::XMLElement& xml_element)
 {

--- a/tesseract_motion_planners/ompl/src/profile/ompl_default_plan_profile.cpp
+++ b/tesseract_motion_planners/ompl/src/profile/ompl_default_plan_profile.cpp
@@ -55,6 +55,7 @@ OMPLDefaultPlanProfile::OMPLDefaultPlanProfile(const tinyxml2::XMLElement& xml_e
   const tinyxml2::XMLElement* planning_time_element = xml_element.FirstChildElement("PlanningTime");
   const tinyxml2::XMLElement* max_solutions_element = xml_element.FirstChildElement("MaxSolutions");
   const tinyxml2::XMLElement* simplify_element = xml_element.FirstChildElement("Simplify");
+  const tinyxml2::XMLElement* fast_simplify_element = xml_element.FirstChildElement("FastSimplifyIfRequired");
   const tinyxml2::XMLElement* optimize_element = xml_element.FirstChildElement("Optimize");
   const tinyxml2::XMLElement* planners_element = xml_element.FirstChildElement("Planners");
   //  const tinyxml2::XMLElement* collision_check_element = xml_element.FirstChildElement("CollisionCheck");
@@ -113,6 +114,13 @@ OMPLDefaultPlanProfile::OMPLDefaultPlanProfile(const tinyxml2::XMLElement& xml_e
       throw std::runtime_error("OMPLPlanProfile: Error parsing Simplify string");
   }
 
+  if (fast_simplify_element != nullptr)
+  {
+    status = fast_simplify_element->QueryBoolText(&fast_simplify_if_required);
+    if (status != tinyxml2::XML_NO_ATTRIBUTE && status != tinyxml2::XML_SUCCESS)
+      throw std::runtime_error("OMPLPlanProfile: Error parsing Simplify string");
+  }
+
   if (optimize_element != nullptr)
   {
     status = optimize_element->QueryBoolText(&optimize);
@@ -133,92 +141,77 @@ OMPLDefaultPlanProfile::OMPLDefaultPlanProfile(const tinyxml2::XMLElement& xml_e
 
       switch (type)
       {
-        case static_cast<int>(OMPLPlannerType::SBL):
-        {
+        case static_cast<int>(OMPLPlannerType::SBL): {
           SBLConfigurator::ConstPtr ompl_planner = std::make_shared<const SBLConfigurator>(*e);
           planners.push_back(ompl_planner);
           break;
         }
-        case static_cast<int>(OMPLPlannerType::EST):
-        {
+        case static_cast<int>(OMPLPlannerType::EST): {
           ESTConfigurator::ConstPtr ompl_planner = std::make_shared<const ESTConfigurator>(*e);
           planners.push_back(ompl_planner);
           break;
         }
-        case static_cast<int>(OMPLPlannerType::LBKPIECE1):
-        {
+        case static_cast<int>(OMPLPlannerType::LBKPIECE1): {
           LBKPIECE1Configurator::ConstPtr ompl_planner = std::make_shared<const LBKPIECE1Configurator>(*e);
           planners.push_back(ompl_planner);
           break;
         }
-        case static_cast<int>(OMPLPlannerType::BKPIECE1):
-        {
+        case static_cast<int>(OMPLPlannerType::BKPIECE1): {
           BKPIECE1Configurator::ConstPtr ompl_planner = std::make_shared<const BKPIECE1Configurator>(*e);
           planners.push_back(ompl_planner);
           break;
         }
-        case static_cast<int>(OMPLPlannerType::KPIECE1):
-        {
+        case static_cast<int>(OMPLPlannerType::KPIECE1): {
           KPIECE1Configurator::ConstPtr ompl_planner = std::make_shared<const KPIECE1Configurator>(*e);
           planners.push_back(ompl_planner);
           break;
         }
-        case static_cast<int>(OMPLPlannerType::BiTRRT):
-        {
+        case static_cast<int>(OMPLPlannerType::BiTRRT): {
           BiTRRTConfigurator::ConstPtr ompl_planner = std::make_shared<const BiTRRTConfigurator>(*e);
           planners.push_back(ompl_planner);
           break;
         }
-        case static_cast<int>(OMPLPlannerType::RRT):
-        {
+        case static_cast<int>(OMPLPlannerType::RRT): {
           RRTConfigurator::ConstPtr ompl_planner = std::make_shared<const RRTConfigurator>(*e);
           planners.push_back(ompl_planner);
           break;
         }
-        case static_cast<int>(OMPLPlannerType::RRTConnect):
-        {
+        case static_cast<int>(OMPLPlannerType::RRTConnect): {
           RRTConnectConfigurator::ConstPtr ompl_planner = std::make_shared<const RRTConnectConfigurator>(*e);
           planners.push_back(ompl_planner);
           break;
         }
-        case static_cast<int>(OMPLPlannerType::RRTstar):
-        {
+        case static_cast<int>(OMPLPlannerType::RRTstar): {
           RRTstarConfigurator::ConstPtr ompl_planner = std::make_shared<const RRTstarConfigurator>(*e);
           planners.push_back(ompl_planner);
           break;
         }
-        case static_cast<int>(OMPLPlannerType::TRRT):
-        {
+        case static_cast<int>(OMPLPlannerType::TRRT): {
           TRRTConfigurator::ConstPtr ompl_planner = std::make_shared<const TRRTConfigurator>(*e);
           planners.push_back(ompl_planner);
           break;
         }
-        case static_cast<int>(OMPLPlannerType::PRM):
-        {
+        case static_cast<int>(OMPLPlannerType::PRM): {
           PRMConfigurator::ConstPtr ompl_planner = std::make_shared<const PRMConfigurator>(*e);
           planners.push_back(ompl_planner);
           break;
         }
-        case static_cast<int>(OMPLPlannerType::PRMstar):
-        {
+        case static_cast<int>(OMPLPlannerType::PRMstar): {
           PRMstarConfigurator::ConstPtr ompl_planner = std::make_shared<const PRMstarConfigurator>(*e);
           planners.push_back(ompl_planner);
           break;
         }
-        case static_cast<int>(OMPLPlannerType::LazyPRMstar):
-        {
+        case static_cast<int>(OMPLPlannerType::LazyPRMstar): {
           LazyPRMstarConfigurator::ConstPtr ompl_planner = std::make_shared<const LazyPRMstarConfigurator>(*e);
           planners.push_back(ompl_planner);
           break;
         }
-        case static_cast<int>(OMPLPlannerType::SPARS):
-        {
+        case static_cast<int>(OMPLPlannerType::SPARS): {
           SPARSConfigurator::ConstPtr ompl_planner = std::make_shared<const SPARSConfigurator>(*e);
           planners.push_back(ompl_planner);
           break;
         }
-        default:
-        {
+        default: {
           throw std::runtime_error("Unsupported OMPL Planner type");
         }
       }
@@ -290,6 +283,7 @@ void OMPLDefaultPlanProfile::setup(OMPLProblem& prob) const
   prob.planning_time = planning_time;
   prob.max_solutions = max_solutions;
   prob.simplify = simplify;
+  prob.fast_simplify_if_required = fast_simplify_if_required;
   prob.optimize = optimize;
 
   prob.contact_checker->applyContactManagerConfig(collision_check_config.contact_manager_config);
@@ -665,6 +659,10 @@ tinyxml2::XMLElement* OMPLDefaultPlanProfile::toXML(tinyxml2::XMLDocument& doc) 
   tinyxml2::XMLElement* xml_simplify = doc.NewElement("Simplify");
   xml_simplify->SetText(simplify);
   xml_ompl->InsertEndChild(xml_simplify);
+
+  tinyxml2::XMLElement* xml_fast_simplify_if_required = doc.NewElement("FastSimplifyIfRequired");
+  xml_simplify->SetText(fast_simplify_if_required);
+  xml_ompl->InsertEndChild(xml_fast_simplify_if_required);
 
   tinyxml2::XMLElement* xml_optimize = doc.NewElement("Optimize");
   xml_optimize->SetText(optimize);


### PR DESCRIPTION
[ompl's simplify method](https://github.com/ompl/ompl/blob/dad8a4511f671f11b7a9f1718d88e7a3a47d4768/src/ompl/geometric/src/PathSimplifier.cpp#L398) does a bunch of stuff and can take a long time to run.  This will attempt to only run reduceVertices and do the minimum amount of reduction when the path has too many states, and the plan does not have simplify set true.
 
Planners are incomplete: XML methods are not added.